### PR TITLE
Fix: Add requires_grad=True to Loss Tensor in BCAgent Class

### DIFF
--- a/a1/bc_agent.py
+++ b/a1/bc_agent.py
@@ -136,5 +136,5 @@ class BCAgent(base_agent.BaseAgent):
         TODO 1.2: Implement code to calculate the loss for training the policy.
         '''
         # placeholder
-        loss = torch.zeros(1)
+        loss = torch.zeros(1, requires_grad=True)
         return loss


### PR DESCRIPTION
Hello,

First of all, thank you so much for making this reinforcement learning assignment available. It's been an incredible learning opportunity for me!

While working on the assignment, I noticed a minor issue in the part of the `BCAgent` class that we're meant to modify. The loss tensor was initialized with `torch.zeros(1)`, and for the purposes of backpropagation during training, it might be more appropriate to initialize it as `torch.zeros(1, requires_grad=True)`.

**Changes**:
- Updated the loss tensor initialization in `_compute_actor_loss` from `torch.zeros(1)` to `torch.zeros(1, requires_grad=True)`.

I understand that this is a part of the code that's intended to be modified, so it's a minor point. I thought it could be helpful for future work.

Would appreciate it if you could take a quick look.

Thank you again for this wonderful learning experience!